### PR TITLE
Border style `topDivider` added to documentation.

### DIFF
--- a/docs/user-interface-tools/control-objects.rst
+++ b/docs/user-interface-tools/control-objects.rst
@@ -409,7 +409,9 @@ To add to a window ``w``::
                            - ``name``: A unique name for the control.
                            - ``borderStyle``: A string that specifies the appearance of the
                              border drawn around the panel. One of ``black``, ``etched``,
-                             ``gray``, ``raised`` or ``sunken``. Default is ``etched``.
+                             ``gray``, ``raised``, ``sunken`` or ``topDivider``.
+                             ``topDivider`` draws a horizonal line at the top of the panel
+                             only. Default is ``etched``.
                            - ``subPanelCoordinates``: When true, this panel automatically
                              adjusts the positions of its children for compatability with
                              Photoshop CS. Default is false, meaning that the panel does

--- a/docs/user-interface-tools/control-objects.rst
+++ b/docs/user-interface-tools/control-objects.rst
@@ -420,6 +420,9 @@ To add to a window ``w``::
 
 =======================  ==================================================================
 
+.. warning::
+    The ``topDivider`` property is officially undocumented and was found via research. Please contribute if you have more information on it!
+
 .. _control-type-progressbar:
 
 progressbar


### PR DESCRIPTION
The Adobe Photoshop script "Image Processor.jsx" at
`C:\Program Files\Adobe\Adobe Photoshop 2022\Presets\Scripts`
comes with a border style value of `topDivider` for a number
of panels.

This value draws a gray line at the top of a panel:

![Image Processor Dialog (original)](https://user-images.githubusercontent.com/9283914/158035739-abfa4d46-cb3f-480e-9142-5c4286c33092.png)

The `topDivider` value is currently undocumented. This pull
request adds the corresponding documentation.