### PR TITLE
added onEnterKey as a editText callback

### DIFF
--- a/docs/user-interface-tools/control-objects.rst
+++ b/docs/user-interface-tools/control-objects.rst
@@ -1914,6 +1914,14 @@ The list's ``selection`` property is set to the clicked item.
 
 --------------------------------------------------------------------------------
 
+.. _control-event-onenterkey:
+
+onEnterKey
+*************
+Called when the user presses return or enter in a :ref:`control-type-edittext` control.
+
+--------------------------------------------------------------------------------
+
 .. _control-event-ondraw:
 
 onDraw

--- a/docs/user-interface-tools/control-objects.rst
+++ b/docs/user-interface-tools/control-objects.rst
@@ -1918,6 +1918,10 @@ The list's ``selection`` property is set to the clicked item.
 
 onEnterKey
 *************
+
+.. warning::
+  This method/property is officially undocumented and was found via research. The information here may be inaccurate, and this whole method/property may disappear or stop working some point. Please contribute if you have more information on it!
+
 Called when the user presses return or enter in a :ref:`control-type-edittext` control.
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This wasn't listed as a callback but it works, unlike  {enterKeySignalsOnChange: true} in the creation properties