### PR TITLE
Changes in the description of various Unary Operators on UnitValue object.

### DIFF
--- a/docs/extendscript-tools-features/specifying-measurement-values.md
+++ b/docs/extendscript-tools-features/specifying-measurement-values.md
@@ -211,10 +211,10 @@ UnitValue objects can be used in computational JavaScript expressions. The way t
 
 |   Operator   |                                Behaviour                                |
 | ------------ | ----------------------------------------------------------------------- |
-| `~unitValue` | The numeric value is converted to a 32-bit integer with inverted bits.  |
+| `~unitValue` | Result is a new UnitValue with the same type, but value converted to a 32-bit integer and inverted bitwise. |
 | `!unitValue` | Result is `true` if the numeric value is nonzero, `false` if it is not. |
-| `+unitValue` | Result is the numeric value.                                            |
-| `-unitValue` | Result is the negated numeric value.                                    |
+| `+unitValue` | Result is a new UnitValue with the same type and value as the original. |
+| `-unitValue` | Result is a new UnitValue with the same type and negated value from the original |
 
 ### Binary operators `(+, -, *, /, %)`
 


### PR DESCRIPTION
Changes in the description of various Unary Operators on UnitValue object. 

These changes are done based on the Illustrator UserVoice issue - https://illustrator.uservoice.com/forums/908050-illustrator-desktop-sdk-scripting-issues/suggestions/48532838-bug-javascript-unary-operators-and-do-not

I am part of Illustrator Engineering team making this change after having discussion with Uservoice issue reporter https://illustrator.uservoice.com/users/6504169733-nihiltres